### PR TITLE
Added additional spacing and background color for mobile sidebar nav

### DIFF
--- a/docs/css/_nav-and-width.css
+++ b/docs/css/_nav-and-width.css
@@ -92,8 +92,17 @@ body.close .sidebar-toggle-button span:nth-child(3) {
 
 /* Edit sidebar when screen is small and there is a mobile menu */
 @media screen and (max-width: 768px) {
-  .sidebar-toggle {
+	body .sidebar-toggle {
     padding: 10px;
+		left: 20px;
+		background-color: var(--color-docs-nav-bkg);
+		bottom: 30px;
+  }
+	body.sticky .sidebar-toggle {
+    padding: 10px;
+		left: 20px;
+		background-color: var(--color-docs-nav-bkg);
+		bottom: 30px;
   }
 
   body .content {


### PR DESCRIPTION
The sidebar hamburger menu was a little too nested in the corner of the screen. I've gone ahead and added some CSS to the _nav-and-width.css file to push the nav menu icon a bit out from the corner of the screen.